### PR TITLE
Mixpanel incremental workflow

### DIFF
--- a/td_load/mixpanel/config/daily_load.yml
+++ b/td_load/mixpanel/config/daily_load.yml
@@ -5,54 +5,54 @@ in:
   timezone: ${mixpanel.timezone}
   from_date: ${mixpanel.from_date}
   fetch_days: ${mixpanel.fetch_days}
+  latest_fetched_time: ${last_results.latest_fetched_time}
+  incremental_column: ${mixpanel.incremental_column}
   columns:
-  - name: event
-    type: string
-  - name: "$browser"
-    type: string
-  - name: "$browser_version"
-    type: long
-  - name: "$city"
-    type: string
-  - name: "$current_url"
-    type: string
-  - name: "$initial_referrer"
-    type: string
-  - name: "$initial_referring_domain"
-    type: string
-  - name: "$lib_version"
-    type: string
-  - name: "$os"
-    type: string
-  - name: "$referrer"
-    type: string
-  - name: "$referring_domain"
-    type: string
-  - name: "$region"
-    type: string
-  - name: "$screen_height"
-    type: long
-  - name: "$screen_width"
-    type: long
-  - name: ENV
-    type: string
-  - name: RAILS_ENV
-    type: string
-  - name: distinct_id
-    type: long
-  - name: from
-    type: string
-  - name: job_id
-    type: long
-  - name: mp_country_code
-    type: string
-  - name: mp_lib
-    type: string
-  - name: name
-    type: string
-  - name: time
-    type: long
-out: {}
+  - {name: time, type: long}
+  - {name: event, type: string}
+  - {name: distinct_id, type: string}
+  - {name: $app_build_number, type: long}
+  - {name: $app_release, type: long}
+  - {name: $app_version, type: string}
+  - {name: $app_version_string, type: string}
+  - {name: $bluetooth_enabled, type: boolean}
+  - {name: $bluetooth_version, type: string}
+  - {name: $brand, type: string}
+  - {name: $carrier, type: string}
+  - {name: $city, type: string}
+  - {name: $google_play_services, type: string}
+  - {name: $has_nfc, type: boolean}
+  - {name: $has_telephone, type: boolean}
+  - {name: $lib_version, type: string}
+  - {name: $manufacturer, type: string}
+  - {name: $model, type: string}
+  - {name: $os, type: string}
+  - {name: $os_version, type: string}
+  - {name: $region, type: string}
+  - {name: $screen_dpi, type: long}
+  - {name: $screen_height, type: long}
+  - {name: $screen_width, type: long}
+  - {name: $wifi, type: boolean}
+  - {name: APK_version, type: string}
+  - {name: AssetID, type: string}
+  - {name: ClientID, type: string}
+  - {name: ClinicID, type: long}
+  - {name: ClinicName, type: string}
+  - {name: ExamRoom, type: string}
+  - {name: TimeStamp, type: long}
+  - {name: asset, type: string}
+  - {name: content-type, type: string}
+  - {name: date, type: timestamp, format: '%Y-%m-%dT%H:%M:%S'}
+  - {name: display-seconds, type: long}
+  - {name: freq, type: long}
+  - {name: full-screen, type: boolean}
+  - {name: is-sponsor, type: boolean}
+  - {name: mp_country_code, type: string}
+  - {name: mp_lib, type: string}
+  - {name: mp_processing_time_ms, type: long}
+  - {name: salesforce-campaign-id, type: string}
+  - {name: sponsor-name, type: string}
+  out: {}
 exec: {}
 filters:
 - type: rename

--- a/td_load/mixpanel/daily_load.dig
+++ b/td_load/mixpanel/daily_load.dig
@@ -15,6 +15,7 @@ _export:
     timezone: "US/Pacific"
     from_date: "${last_session_date}"
     fetch_days: 1
+    incremental_column: mp_processing_time_ms
   td:
     dest_db: dest_db
     dest_table: dest_table
@@ -24,7 +25,15 @@ _export:
   database: ${td.dest_db}
   create_tables: ["${td.dest_table}"]
 
++query_latest_fetched_time:
+  td_run>: latest_fetched_time_query
+  database: ${td.dest_db}
+  store_last_results: true
+
+
+
 +load:
   td_load>: config/daily_load.yml
   database: ${td.dest_db}
   table: ${td.dest_table}
+


### PR DESCRIPTION
Hi @kamikaseda,
embulk-input-mixpanel will have 2 more options to let user use custom column as incremental column, that column will be use as condition for mixpanel API query. This feature can also be used with workflow too. The flow would be: 
```
td_run> run a saved query to calculate the latest ingestion timestamp, expose query latest resutls
--> Run Mixpanel td_load with YAML configuration file interpolated with that latest ingestion timestamp
```
I'm wondering if it's ok to merge this example workflow to this repository or not. If It ok then I will update README file. Or we should make another folder for this one to not confuse user.

Changes:
Add query to calculate max ingest timestamp.
Add incremental_column and latest_fetched_time to mixpanel configuration

Thanks