### PR TITLE
Fix README

### DIFF
--- a/scenarios/import_bigquery_to_treasuredata/README.md
+++ b/scenarios/import_bigquery_to_treasuredata/README.md
@@ -33,7 +33,7 @@ Now you can reference these credentials by `${secret:}` syntax in yml file of `t
 Finally, you can trigger the session manually.
 
     # Run
-    $ td wf start bq_to_td main.dig --session now
+    $ td wf start bq_to_td main --session now
 
 # Next Step
 

--- a/scenarios/intermediate_table/README.md
+++ b/scenarios/intermediate_table/README.md
@@ -46,7 +46,7 @@ First, please upload the workflow.
 You can trigger the session manually to watch it execute.
 
     # Run
-    $ td wf start bq_to_td main.dig --session now
+    $ td wf start bq_to_td main --session now
 
 
 # Next Step


### PR DESCRIPTION
Hi.

``td wf start`` command takes arguments ``project name`` and ``workflow name``.
However, the command takes ``project name`` and ``file name`` in these README.