### PR TITLE
Refine min-max normalization and missing value interpolation scheme

### DIFF
--- a/machine-learning/ctr-prediction/common/prepare_data.dig
+++ b/machine-learning/ctr-prediction/common/prepare_data.dig
@@ -15,25 +15,24 @@
     engine: presto
     create_table: samples_test
 
++minmax:
+  +train:
+    td>: ../queries/minmax_train.sql
+    engine: presto
+    store_last_results: true
+
+  +test:
+    td>: ../queries/minmax_test.sql
+    engine: presto
+    store_last_results: true
+
 +preprocess:
   _parallel: true
 
   +train:
-    +minmax:
-      td>: ../queries/minmax_train.sql
-      engine: presto
-      store_last_results: true
-
-    +run:
-      td>: ../queries/preprocess_train.sql
-      create_table: train
+    td>: ../queries/preprocess_train.sql
+    create_table: train
 
   +test:
-    +minmax:
-      td>: ../queries/minmax_test.sql
-      engine: presto
-      store_last_results: true
-
-    +run:
-      td>: ../queries/preprocess_test.sql
-      create_table: test
+    td>: ../queries/preprocess_test.sql
+    create_table: test

--- a/machine-learning/ctr-prediction/queries/minmax_test.sql
+++ b/machine-learning/ctr-prediction/queries/minmax_test.sql
@@ -1,17 +1,32 @@
 select
-  min(i1) as test_min1, max(i1) as test_max1,
-  min(i2) as test_min2, max(i2) as test_max2,
-  min(i3) as test_min3, max(i3) as test_max3,
-  min(i4) as test_min4, max(i4) as test_max4,
-  min(i5) as test_min5, max(i5) as test_max5,
-  min(i6) as test_min6, max(i6) as test_max6,
-  min(i7) as test_min7, max(i7) as test_max7,
-  min(i8) as test_min8, max(i8) as test_max8,
-  min(i9) as test_min9, max(i9) as test_max9,
-  min(i10) as test_min10, max(i10) as test_max10,
-  min(i11) as test_min11, max(i11) as test_max11,
-  min(i12) as test_min12, max(i12) as test_max12,
-  min(i13) as test_min13, max(i13) as test_max13
+  -- carrying over the previous "last_results" (= min-max for training)
+  ${td.last_results.train_min1} as train_min1, ${td.last_results.train_max1} as train_max1,
+  ${td.last_results.train_min2} as train_min2, ${td.last_results.train_max2} as train_max2,
+  ${td.last_results.train_min3} as train_min3, ${td.last_results.train_max3} as train_max3,
+  ${td.last_results.train_min4} as train_min4, ${td.last_results.train_max4} as train_max4,
+  ${td.last_results.train_min5} as train_min5, ${td.last_results.train_max5} as train_max5,
+  ${td.last_results.train_min6} as train_min6, ${td.last_results.train_max6} as train_max6,
+  ${td.last_results.train_min7} as train_min7, ${td.last_results.train_max7} as train_max7,
+  ${td.last_results.train_min8} as train_min8, ${td.last_results.train_max8} as train_max8,
+  ${td.last_results.train_min9} as train_min9, ${td.last_results.train_max9} as train_max9,
+  ${td.last_results.train_min10} as train_min10, ${td.last_results.train_max10} as train_max10,
+  ${td.last_results.train_min11} as train_min11, ${td.last_results.train_max11} as train_max11,
+  ${td.last_results.train_min12} as train_min12, ${td.last_results.train_max12} as train_max12,
+  ${td.last_results.train_min13} as train_min13, ${td.last_results.train_max13} as train_max13,
+  -- min-max for testing should be computed on all of observed samples (i.e., train + test samples)
+  least(min(i1), ${td.last_results.train_min1}) as test_min1, greatest(max(i1), ${td.last_results.train_max1}) as test_max1,
+  least(min(i2), ${td.last_results.train_min2}) as test_min2, greatest(max(i2), ${td.last_results.train_max2}) as test_max2,
+  least(min(i3), ${td.last_results.train_min3}) as test_min3, greatest(max(i3), ${td.last_results.train_max3}) as test_max3,
+  least(min(i4), ${td.last_results.train_min4}) as test_min4, greatest(max(i4), ${td.last_results.train_max4}) as test_max4,
+  least(min(i5), ${td.last_results.train_min5}) as test_min5, greatest(max(i5), ${td.last_results.train_max5}) as test_max5,
+  least(min(i6), ${td.last_results.train_min6}) as test_min6, greatest(max(i6), ${td.last_results.train_max6}) as test_max6,
+  least(min(i7), ${td.last_results.train_min7}) as test_min7, greatest(max(i7), ${td.last_results.train_max7}) as test_max7,
+  least(min(i8), ${td.last_results.train_min8}) as test_min8, greatest(max(i8), ${td.last_results.train_max8}) as test_max8,
+  least(min(i9), ${td.last_results.train_min9}) as test_min9, greatest(max(i9), ${td.last_results.train_max9}) as test_max9,
+  least(min(i10), ${td.last_results.train_min10}) as test_min10, greatest(max(i10), ${td.last_results.train_max10}) as test_max10,
+  least(min(i11), ${td.last_results.train_min11}) as test_min11, greatest(max(i11), ${td.last_results.train_max11}) as test_max11,
+  least(min(i12), ${td.last_results.train_min12}) as test_min12, greatest(max(i12), ${td.last_results.train_max12}) as test_max12,
+  least(min(i13), ${td.last_results.train_min13}) as test_min13, greatest(max(i13), ${td.last_results.train_max13}) as test_max13
 from
   samples_test
 ;

--- a/machine-learning/sfdc-predictive-analytics/common/run.dig
+++ b/machine-learning/sfdc-predictive-analytics/common/run.dig
@@ -1,25 +1,24 @@
++minmax:
+  +train:
+    td>: ../queries/minmax_train.sql
+    store_last_results: true
+
+  +test:
+    td>: ../queries/minmax_test.sql
+    store_last_results: true
+
 +preprocess:
   _parallel: true
 
   +train:
-    +minmax:
-      td>: ../queries/minmax_train.sql
-      store_last_results: true
-
-    +run:
-      td>: ../queries/${task}/preprocess_train.sql
-      create_table: train_${task}
-      engine: hive
+    td>: ../queries/${task}/preprocess_train.sql
+    create_table: train_${task}
+    engine: hive
 
   +test:
-    +minmax:
-      td>: ../queries/minmax_test.sql
-      store_last_results: true
-
-    +run:
-      td>: ../queries/${task}/preprocess_test.sql
-      create_table: test_${task}
-      engine: hive
+    td>: ../queries/${task}/preprocess_test.sql
+    create_table: test_${task}
+    engine: hive
 
 +train:
   td>: ../queries/train.sql

--- a/machine-learning/sfdc-predictive-analytics/queries/minmax_test.sql
+++ b/machine-learning/sfdc-predictive-analytics/queries/minmax_test.sql
@@ -1,10 +1,19 @@
 SELECT
+  -- carrying over the previous "last_results" for training
+  ${td.last_results.train_avg_annualrevenue} AS train_avg_annualrevenue,
+  ${td.last_results.train_avg_numberofemployees} AS train_avg_numberofemployees,
+  ${td.last_results.train_max_annualrevenue} AS train_max_annualrevenue,
+  ${td.last_results.train_min_annualrevenue} AS train_min_annualrevenue,
+  ${td.last_results.train_max_numberofemployees} AS train_max_numberofemployees,
+  ${td.last_results.train_min_numberofemployees} AS train_min_numberofemployees,
   -- fill NULLs w/ mean values
   AVG(annualrevenue) AS test_avg_annualrevenue,
   AVG(numberofemployees) AS test_avg_numberofemployees,
-  -- for min-max normalization
-  MAX(annualrevenue) AS test_max_annualrevenue, MIN(annualrevenue) AS test_min_annualrevenue,
-  MAX(numberofemployees) AS test_max_numberofemployees, MIN(numberofemployees) AS test_min_numberofemployees
+  -- min-max for testing should be computed on all of observed samples (i.e., train + test samples)
+  greatest(MAX(annualrevenue), ${td.last_results.train_max_annualrevenue}) AS test_max_annualrevenue,
+  least(MIN(annualrevenue), ${td.last_results.train_min_annualrevenue}) AS test_min_annualrevenue,
+  greatest(MAX(numberofemployees), ${td.last_results.train_max_numberofemployees}) AS test_max_numberofemployees,
+  least(MIN(numberofemployees), ${td.last_results.train_min_numberofemployees}) AS test_min_numberofemployees
 FROM
   samples_test_${task}
 ;

--- a/machine-learning/sfdc-predictive-analytics/queries/minmax_test.sql
+++ b/machine-learning/sfdc-predictive-analytics/queries/minmax_test.sql
@@ -6,9 +6,6 @@ SELECT
   ${td.last_results.train_min_annualrevenue} AS train_min_annualrevenue,
   ${td.last_results.train_max_numberofemployees} AS train_max_numberofemployees,
   ${td.last_results.train_min_numberofemployees} AS train_min_numberofemployees,
-  -- fill NULLs w/ mean values
-  AVG(annualrevenue) AS test_avg_annualrevenue,
-  AVG(numberofemployees) AS test_avg_numberofemployees,
   -- min-max for testing should be computed on all of observed samples (i.e., train + test samples)
   greatest(MAX(annualrevenue), ${td.last_results.train_max_annualrevenue}) AS test_max_annualrevenue,
   least(MIN(annualrevenue), ${td.last_results.train_min_annualrevenue}) AS test_min_annualrevenue,

--- a/machine-learning/sfdc-predictive-analytics/queries/opportunity/preprocess_test.sql
+++ b/machine-learning/sfdc-predictive-analytics/queries/opportunity/preprocess_test.sql
@@ -8,7 +8,7 @@ SELECT
       rescale(
         IF(
           annualrevenue IS NULL,
-          ${td.last_results.test_avg_annualrevenue},
+          ${td.last_results.train_avg_annualrevenue},
           annualrevenue
         ),
         ${td.last_results.test_min_annualrevenue},
@@ -17,7 +17,7 @@ SELECT
       rescale(
         IF(
           numberofemployees IS NULL,
-          ${td.last_results.test_avg_numberofemployees},
+          ${td.last_results.train_avg_numberofemployees},
           numberofemployees
         ),
         ${td.last_results.test_min_numberofemployees},

--- a/machine-learning/sfdc-predictive-analytics/queries/qualified_lead/preprocess_test.sql
+++ b/machine-learning/sfdc-predictive-analytics/queries/qualified_lead/preprocess_test.sql
@@ -8,7 +8,7 @@ SELECT
       rescale(
         IF(
           annualrevenue IS NULL,
-          ${td.last_results.test_avg_annualrevenue},
+          ${td.last_results.train_avg_annualrevenue},
           annualrevenue
         ),
         ${td.last_results.test_min_annualrevenue},
@@ -17,7 +17,7 @@ SELECT
       rescale(
         IF(
           numberofemployees IS NULL,
-          ${td.last_results.test_avg_numberofemployees},
+          ${td.last_results.train_avg_numberofemployees},
           numberofemployees
         ),
         ${td.last_results.test_min_numberofemployees},


### PR DESCRIPTION
In the ML workflows, min/max values for evaluation should be computed on all observed data including train samples.

Meanwhile, missing values (NULLs) in test data are currently filled by avg. of test samples, but interpolating avg. of train data is more reasonable because the distribution of test samples is likely to be imbalanced. 