### PR TITLE
Fix secrets command

### DIFF
--- a/emr/single_node_single_task/README.md
+++ b/emr/single_node_single_task/README.md
@@ -15,16 +15,16 @@ This example workflow also uses the [Sample Datasets](https://console.treasureda
 For local mode, register your AWS credentials at first
 
     # Set Secrets for local mode
-    $ td wf secrets --local --set aws.emr.access_key_id=xxxxx
-    $ td wf secrets --local --set aws.emr.secret_access_key=xxxxx
+    $ td wf secrets --local --set aws.emr.access_key_id
+    $ td wf secrets --local --set aws.emr.secret_access_key
 
 For server mode, upload the project to Treasure Data, and then register your AWS credentials into the uploaded project.
 
     # Upload
     $ td wf push td_emr_example
     # Set secrets
-    $ td wf secrets --project td_emr_example --set aws.emr.access_key_id=xxxxx
-    $ td wf secrets --project td_emr_example --set aws.emr.secret_access_key=xxxxx
+    $ td wf secrets --project td_emr_example --set aws.emr.access_key_id
+    $ td wf secrets --project td_emr_example --set aws.emr.secret_access_key
 
 Create a sample database for this workflow to push it's job to
 	

--- a/machine-learning/house_price/README.md
+++ b/machine-learning/house_price/README.md
@@ -35,7 +35,7 @@ If you want to run feature selection with py> operator, you can execute as follo
 ```sh
 $ ./data.sh
 $ td wf push regressor
-$ td wf secrets --project regressor --set apikey endpoint
+$ td wf secrets --project regressor --set apikey=$TD_API_KEY --set endpoint=$TD_API_SERVER
 $ td wf start regressor regression-py
 ```
 

--- a/machine-learning/house_price/README.md
+++ b/machine-learning/house_price/README.md
@@ -35,7 +35,7 @@ If you want to run feature selection with py> operator, you can execute as follo
 ```sh
 $ ./data.sh
 $ td wf push regressor
-$ td wf secrets --project regressor --set apikey=$TD_API_KEY --set endpoint=$TD_API_SERVER
+$ td wf secrets --project regressor --set apikey endpoint
 $ td wf start regressor regression-py
 ```
 

--- a/mail/README.md
+++ b/mail/README.md
@@ -13,10 +13,10 @@ First, please make your dig file and mail text.
 Second, please set the secrets using `td wf secrets` command. The mail operator uses that secrets for sending email. For more details, please see digdag documentation [secrets](http://docs.digdag.io/command_reference.html#secrets) and [mail operator](http://docs.digdag.io/operators/mail.html#secrets).
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set mail.host=xyzxyz    
-    $ td wf secrets --local --set mail.port=xyzx    
-    $ td wf secrets --local --set mail.username=xyzxyz    
-    $ td wf secrets --local --set mail.password=xyzxyz    
+    $ td wf secrets --local --set mail.host
+    $ td wf secrets --local --set mail.port
+    $ td wf secrets --local --set mail.username
+    $ td wf secrets --local --set mail.password
 
 Now, you can trigger the session manually.
 

--- a/pg/README.md
+++ b/pg/README.md
@@ -12,10 +12,10 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set password for postgre server using `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project pg_example --set pg.password=xyzxyz
+    $ td wf secrets --project pg_example --set pg.password
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set pg.password=xyzxyz    
+    $ td wf secrets --local --set pg.password
 
 Now, you can trigger the session manually.
 

--- a/scenarios/import_bigquery_to_treasuredata/README.md
+++ b/scenarios/import_bigquery_to_treasuredata/README.md
@@ -26,7 +26,7 @@ Next, set database credentials by using the `td wf secrets` command. See [exampl
     
     # Set Secrets for `td_load>:` operator
     $ td wf secrets --project bq_to_td --set gcp.jsonkey=@converted.json
-    $ td wf secrets --project bq_to_td --set td.apikey=YOURAPIKEY
+    $ td wf secrets --project bq_to_td --set td.apikey
 
 Now you can reference these credentials by `${secret:}` syntax in yml file of `td_load` operator.
 

--- a/scenarios/marketo_daily_load/README.md
+++ b/scenarios/marketo_daily_load/README.md
@@ -16,9 +16,9 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project marketo_daily_load --set marketo.account_id=xxxxxx
-    $ td wf secrets --project marketo_daily_load --set marketo.client_id=yyyyy
-    $ td wf secrets --project marketo_daily_load --set marketo.client_secret=zzzzz
+    $ td wf secrets --project marketo_daily_load --set marketo.account_id
+    $ td wf secrets --project marketo_daily_load --set marketo.client_id
+    $ td wf secrets --project marketo_daily_load --set marketo.client_secret
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td/another_td/README.md
+++ b/td/another_td/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project another_td_account --set key=value
+    $ td wf secrets --project another_td_account --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/bigquery/README.md
+++ b/td/bigquery/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_bigquery --set key=value
+    $ td wf secrets --project td_bigquery --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/elasticsearch/README.md
+++ b/td/elasticsearch/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project sample_project --set key=value
+    $ td wf secrets --project sample_project --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/facebook_custom_audience/README.md
+++ b/td/facebook_custom_audience/README.md
@@ -18,10 +18,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask any settings, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_facebook_custom_audience --set key=value
+    $ td wf secrets --project td_facebook_custom_audience --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/ftp/README.md
+++ b/td/ftp/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_ftp --set key=value
+    $ td wf secrets --project td_ftp --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/gcs/README.md
+++ b/td/gcs/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_gcs --set key=value
+    $ td wf secrets --project td_gcs --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/gsheet/README.md
+++ b/td/gsheet/README.md
@@ -26,10 +26,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_gsheet --set key=value
+    $ td wf secrets --project td_gsheet --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/mailchimp/README.md
+++ b/td/mailchimp/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project mailchimp_export --set key=value
+    $ td wf secrets --project mailchimp_export --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/microsoft-azure-blob-storage/README.md
+++ b/td/microsoft-azure-blob-storage/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_azure_blob_storage --set key=value
+    $ td wf secrets --project td_azure_blob_storage --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/microsoft-sql-server/README.md
+++ b/td/microsoft-sql-server/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_sql_server --set key=value
+    $ td wf secrets --project td_sql_server --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/mongodb/README.md
+++ b/td/mongodb/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_mongodb --set key=value
+    $ td wf secrets --project td_mongodb --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/mysql/README.md
+++ b/td/mysql/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_mysql --set key=value
+    $ td wf secrets --project td_mysql --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/nend/README.md
+++ b/td/nend/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_nend --set key=value
+    $ td wf secrets --project td_nend --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/postgresql/README.md
+++ b/td/postgresql/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_postgresql --set key=value
+    $ td wf secrets --project td_postgresql --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/redshift/README.md
+++ b/td/redshift/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project sample_project --set key=value
+    $ td wf secrets --project sample_project --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/s3/README.md
+++ b/td/s3/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project sample_project --set key=value
+    $ td wf secrets --project sample_project --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/salesforce_marketing_cloud_exacttarget/README.md
+++ b/td/salesforce_marketing_cloud_exacttarget/README.md
@@ -23,10 +23,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_sfmc --set key=value
+    $ td wf secrets --project td_sfmc --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/sfdc/README.md
+++ b/td/sfdc/README.md
@@ -23,10 +23,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_sfdc --set key=value
+    $ td wf secrets --project td_sfdc --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/sftp/README.md
+++ b/td/sftp/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_sftp --set key=value
+    $ td wf secrets --project td_sftp --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/tableau/README.md
+++ b/td/tableau/README.md
@@ -24,10 +24,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project tableau --set key=value
+    $ td wf secrets --project tableau --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td/web_server/README.md
+++ b/td/web_server/README.md
@@ -22,10 +22,10 @@ First, please upload your workflow project by `td wf push` command.
 If you want to mask setting, please set it by `td wf secrets` command. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project web_server --set key=value
+    $ td wf secrets --project web_server --set key
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set key=value
+    $ td wf secrets --local --set key
 
 Now you can use these secrets by `${secret:}` syntax in the dig file.
 

--- a/td_load/amplitude/README.md
+++ b/td_load/amplitude/README.md
@@ -14,8 +14,8 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set amplitude.api_key=xyz
-    $ td wf secrets --project td_load_example --set amplitude.secret_key=xyz
+    $ td wf secrets --project td_load_example --set amplitude.api_key
+    $ td wf secrets --project td_load_example --set amplitude.secret_key
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/ftp/README.md
+++ b/td_load/ftp/README.md
@@ -14,16 +14,16 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set FTP credentials by `td wf secrets` command. We recommend you to use text file for setting secret_key_file. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set ftp.host=xyzxyz
-    $ td wf secrets --project td_load_example --set ftp.port=22
-    $ td wf secrets --project td_load_example --set ftp.user=xyzxyz
-    $ td wf secrets --project td_load_example --set ftp.password=xyzxyz
+    $ td wf secrets --project td_load_example --set ftp.host
+    $ td wf secrets --project td_load_example --set ftp.port
+    $ td wf secrets --project td_load_example --set ftp.user
+    $ td wf secrets --project td_load_example --set ftp.password
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set ftp.host=xyzxyz
-    $ td wf secrets --local --set ftp.port=22
-    $ td wf secrets --local --set ftp.user=xyzxyz
-    $ td wf secrets --local --set ftp.password=xyzxyz
+    $ td wf secrets --local --set ftp.host
+    $ td wf secrets --local --set ftp.port
+    $ td wf secrets --local --set ftp.user
+    $ td wf secrets --local --set ftp.password
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/marketo/README.md
+++ b/td_load/marketo/README.md
@@ -14,9 +14,9 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set marketo.account_id=xxxxxx
-    $ td wf secrets --project td_load_example --set marketo.client_id=yyyyy
-    $ td wf secrets --project td_load_example --set marketo.client_secret=zzzzz
+    $ td wf secrets --project td_load_example --set marketo.account_id
+    $ td wf secrets --project td_load_example --set marketo.client_id
+    $ td wf secrets --project td_load_example --set marketo.client_secret
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/mixpanel/README.md
+++ b/td_load/mixpanel/README.md
@@ -14,8 +14,8 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set mixpanel.api_key=xyz
-    $ td wf secrets --project td_load_example --set mixpanel.api_secret=xyz
+    $ td wf secrets --project td_load_example --set mixpanel.api_key
+    $ td wf secrets --project td_load_example --set mixpanel.api_secret
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/mysql/README.md
+++ b/td_load/mysql/README.md
@@ -9,10 +9,10 @@ The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflow
 First, please set database credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set mysql.host=xyz
-    $ td wf secrets --project td_load_example --set mysql.port=3306
-    $ td wf secrets --project td_load_example --set mysql.user=abcde
-    $ td wf secrets --project td_load_example --set mysql.password=fghijklmn
+    $ td wf secrets --project td_load_example --set mysql.host
+    $ td wf secrets --project td_load_example --set mysql.port
+    $ td wf secrets --project td_load_example --set mysql.user
+    $ td wf secrets --project td_load_example --set mysql.password
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/netsuite/README.md
+++ b/td_load/netsuite/README.md
@@ -14,10 +14,10 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set netsuite.email=xyzxyz
-    $ td wf secrets --project td_load_example --set netsuite.password=xyzxyz
-    $ td wf secrets --project td_load_example --set netsuite.account=xyzxyz
-    $ td wf secrets --project td_load_example --set netsuite.role=xyzxyz
+    $ td wf secrets --project td_load_example --set netsuite.email
+    $ td wf secrets --project td_load_example --set netsuite.password
+    $ td wf secrets --project td_load_example --set netsuite.account
+    $ td wf secrets --project td_load_example --set netsuite.role
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/postgresql/README.md
+++ b/td_load/postgresql/README.md
@@ -9,10 +9,10 @@ The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflow
 First, please set database credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set postgresql.host=xyz
-    $ td wf secrets --project td_load_example --set postgresql.port=5432
-    $ td wf secrets --project td_load_example --set postgresql.user=abcde
-    $ td wf secrets --project td_load_example --set postgresql.password=fghijklmn
+    $ td wf secrets --project td_load_example --set postgresql.host
+    $ td wf secrets --project td_load_example --set postgresql.port
+    $ td wf secrets --project td_load_example --set postgresql.user
+    $ td wf secrets --project td_load_example --set postgresql.password
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/s3/README.md
+++ b/td_load/s3/README.md
@@ -14,9 +14,9 @@ First, you can upload the workflow.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set s3.endpoint=s3-us-west-1.amazonaws.com
-    $ td wf secrets --project td_load_example --set s3.access_key_id=xyzxyzxyzxyz
-    $ td wf secrets --project td_load_example --set s3.secret_access_key=xyzxyzxyzxyz
+    $ td wf secrets --project td_load_example --set s3.endpoint
+    $ td wf secrets --project td_load_example --set s3.access_key_id
+    $ td wf secrets --project td_load_example --set s3.secret_access_key
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/sfdc/README.md
+++ b/td_load/sfdc/README.md
@@ -14,12 +14,12 @@ First, you can upload the workflow.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set sfdc.username=xyz
-    $ td wf secrets --project td_load_example --set sfdc.password=xyz
-    $ td wf secrets --project td_load_example --set sfdc.client_id=xyz
-    $ td wf secrets --project td_load_example --set sfdc.client_secret=xyz
-    $ td wf secrets --project td_load_example --set sfdc.security_token=xyz
-    $ td wf secrets --project td_load_example --set sfdc.login_url=http://xyz
+    $ td wf secrets --project td_load_example --set sfdc.username
+    $ td wf secrets --project td_load_example --set sfdc.password
+    $ td wf secrets --project td_load_example --set sfdc.client_id
+    $ td wf secrets --project td_load_example --set sfdc.client_secret
+    $ td wf secrets --project td_load_example --set sfdc.security_token
+    $ td wf secrets --project td_load_example --set sfdc.login_url
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/sfmc/README.md
+++ b/td_load/sfmc/README.md
@@ -11,8 +11,8 @@ The workflow also uses [Secrets](https://docs.treasuredata.com/articles/workflow
 First, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --local --set sfmc.client_id=xyz
-    $ td wf secrets --local --set sfmc.client_secret=xyzyou can upload the workflow.
+    $ td wf secrets --local --set sfmc.client_id
+    $ td wf secrets --local --set sfmc.client_secret
 
     # Run
     $ td wf run daily_load.dig
@@ -27,8 +27,8 @@ You can upload the workflow.
 Please set datasource credentials by `td wf secrets` command for the project
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set sfmc.client_id=xyz
-    $ td wf secrets --project td_load_example --set sfmc.client_secret=xyz
+    $ td wf secrets --project td_load_example --set sfmc.client_id
+    $ td wf secrets --project td_load_example --set sfmc.client_secret
 
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.

--- a/td_load/sftp/README.md
+++ b/td_load/sftp/README.md
@@ -14,17 +14,17 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set SFTP credentials by `td wf secrets` command. We recommend you to use text file for setting secret_key_file. For more details, please see [digdag documentation](http://docs.digdag.io/command_reference.html#secrets)
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set sftp.host=xyzxyz
-    $ td wf secrets --project td_load_example --set sftp.port=22
-    $ td wf secrets --project td_load_example --set sftp.user=xyzxyz
-    $ td wf secrets --project td_load_example --set sftp.secret_key_passphrase=xyzxyz
+    $ td wf secrets --project td_load_example --set sftp.host
+    $ td wf secrets --project td_load_example --set sftp.port
+    $ td wf secrets --project td_load_example --set sftp.user
+    $ td wf secrets --project td_load_example --set sftp.secret_key_passphrase
     $ td wf secrets --project td_load_example --set sftp.secret_key_file=@secret_key_file.txt
 
     # Set Secrets on your local for testing
-    $ td wf secrets --local --set sftp.host=xyzxyz
-    $ td wf secrets --local --set sftp.port=22
-    $ td wf secrets --local --set sftp.user=xyzxyz
-    $ td wf secrets --local --set sftp.secret_key_passphrase=xyzxyz
+    $ td wf secrets --local --set sftp.host
+    $ td wf secrets --local --set sftp.port
+    $ td wf secrets --local --set sftp.user
+    $ td wf secrets --local --set sftp.secret_key_passphrase
     $ td wf secrets --local --set sftp.secret_key_file=@secret_key_file.txt
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.

--- a/td_load/shopify/README.md
+++ b/td_load/shopify/README.md
@@ -14,9 +14,9 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set shopify.apikey=xyzxyz
-    $ td wf secrets --project td_load_example --set shopify.password=xyzxyz
-    $ td wf secrets --project td_load_example --set shopify.store_name=xyzxyz
+    $ td wf secrets --project td_load_example --set shopify.apikey
+    $ td wf secrets --project td_load_example --set shopify.password
+    $ td wf secrets --project td_load_example --set shopify.store_name
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 

--- a/td_load/zendesk/README.md
+++ b/td_load/zendesk/README.md
@@ -14,9 +14,9 @@ First, you can upload the workflow and trigger the session manually.
 Second, please set datasource credentials by `td wf secrets` command.
 
     # Set Secrets
-    $ td wf secrets --project td_load_example --set zendesk.login_url=https://xxxxxxxxx.zendesk.com
-    $ td wf secrets --project td_load_example --set zendesk.username=xyz
-    $ td wf secrets --project td_load_example --set zendesk.token=xyz
+    $ td wf secrets --project td_load_example --set zendesk.login_url
+    $ td wf secrets --project td_load_example --set zendesk.username
+    $ td wf secrets --project td_load_example --set zendesk.token
 
 Now you can reference these credentials by `${secret:}` syntax within yml file for `td_load` operator.
 


### PR DESCRIPTION
The style of `td wf secrets --local --set aws.emr.access_key_id=xxxxx` is not supported. Actually, it does not work on Windows environment. Samples would be better to use interactive mode commands.