### PR TITLE
Corrected null parameter setting

### DIFF
--- a/td/s3/README.md
+++ b/td/s3/README.md
@@ -49,7 +49,7 @@ Available parameters for `result_settings` are here.
 - compression: (string(None|gz), default None)
 - header: (boolean, default true)
 - delimiter: (string(","|"tab"|"|"), default ",")
-- "null": (string("empty"|"\N"|NULL|null|any characters), default "empty")
+- "null": (string("empty"|"\\N"|NULL|null|any characters), default "empty")
 - newline: (string(\r\n(CRLF)|\r(CR)|\n(LF)), default \r\n(CRLF))
 - quote: (string, optional)
 - escape: (string, optional)


### PR DESCRIPTION
The correct value that's accepted for the "null": parameter is `\\N` not `\N`. Entering `\N` writes an empty result for nulls while `\\N` writes the correct `\N` value.