### PR TITLE
Fix incorrect use of Presto's `rand()` function

### DIFF
--- a/machine-learning/ctr-prediction/README.md
+++ b/machine-learning/ctr-prediction/README.md
@@ -18,7 +18,7 @@ For instance, this workflow takes a table of the following form:
 
 Here, each row represents user's single impression for an ad. Impressions can be written by a set of `int` (quantitative) and `string` (categorical) variables such as users' demographics. A column `label` shows whether a user clicked an ad.
 
-**Note:** This template supports tables which have 13 quantitative (i1-i13) and 26 categorical (c1-c26) variables by default.
+> **Note:** This template supports tables which have 13 quantitative (i1-i13) and 26 categorical (c1-c26) variables by default.
 
 If you have more/less quantitative and/or categorical features in a table, you need to modify the following queries appropriately:
 
@@ -41,7 +41,7 @@ $ td wf start ctr-prediction predict_logress --session now -p apikey=${YOUR_TD_A
 * [config/general.yml](config/general.yml) - defines configurable parameters for the prediction.
 
 [<img src="docs/img/capture.png" alt="capture" height=300 />](http://showterm.io/de1678afb369ad82a04bc)
-  
+
 ## Output
 
 The output of workflow is a table that contains predicted CTRs for possible future impressions:
@@ -50,8 +50,10 @@ The output of workflow is a table that contains predicted CTRs for possible futu
 |:---:|:---:|
 |80038 |0.487177|
 |80043|0.9583734|
-|80046 | 0.9104515 | 
+|80046 | 0.9104515 |
 | ... | ... |
+
+> **Note:** Output may change every time the workflow is newly executed due to [randomness in shuffling](./queries/shuffle.sql#L5). Use [Hive version](./queries/shuffle_hive.sql) of the query for making the result repeatable with consistent random seed.
 
 ## Using the Prediction Model in Production System
 
@@ -63,7 +65,7 @@ Once the prediction workflow has been successfully completed, exporting the pred
 2. Load the information to TD workflow:<br/>`$ td wf secrets --project ctr-prediction --set @config/secrets.yml`
 3. Export a `logress_model` table to your MySQL DB:<br/>`td wf start ctr-prediction mysql --session now -p apikey=${YOUR_TD_API_KEY}`
 
-***Note:*** *Make sure a table `logress_model` exists on your MySQL DB as follows.*
+> **Note:** Make sure a table `logress_model` exists on your MySQL DB as follows.
 
 ```sql
 create table logress_model (
@@ -156,7 +158,7 @@ Further readings:
 
 ## How This Workflow Works
 
-For further reading for algorithm and/or workflow details, please refer [this page](docs/more.md). 
+For further reading for algorithm and/or workflow details, please refer [this page](docs/more.md).
 
 ## Conclusion
 

--- a/machine-learning/ctr-prediction/common/prepare_data.dig
+++ b/machine-learning/ctr-prediction/common/prepare_data.dig
@@ -3,6 +3,11 @@
   engine: presto
   create_table: samples_shuffled
 
+# Uncomment this task for repeatable shuffling with consistent random seed:
+#+shuffle_repeatable:
+#  td>: ../queries/shuffle_hive.sql
+#  create_table: samples_shuffled
+
 +split:
   _parallel: true
 

--- a/machine-learning/ctr-prediction/queries/shuffle.sql
+++ b/machine-learning/ctr-prediction/queries/shuffle.sql
@@ -2,6 +2,6 @@ select
   *,
   -- stratified sampling
   count(1) over (partition by label) as per_label_count,
-  rank() over (partition by label order by rand(41)) as rank_in_label
+  rank() over (partition by label order by rand()) as rank_in_label
 from
   ${source}

--- a/machine-learning/ctr-prediction/queries/shuffle_hive.sql
+++ b/machine-learning/ctr-prediction/queries/shuffle_hive.sql
@@ -1,0 +1,11 @@
+select
+  -- explicitly select all columns to exclude `v` column
+  rowid, label,
+  i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13,
+  c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17,
+  c18, c19, c20, c21, c22, c23, c24, c25, c26,
+  -- stratified sampling
+  count(1) over (partition by label) as per_label_count,
+  rank() over (partition by label order by rand(41)) as rank_in_label
+from
+  ${source}

--- a/machine-learning/sfdc-predictive-analytics/experiment.dig
+++ b/machine-learning/sfdc-predictive-analytics/experiment.dig
@@ -29,5 +29,9 @@ _export:
     store_last_results: true
     engine: hive
 
+  # Output may change every time the workflow is newly executed due to
+  # randomness in shuffling. Use Hive and its `rand(int seed)` function at
+  # `+shuffle` in `common/prepare_data.dig` for making the result repeatable
+  # with consistent random seed.
   +show_accuracy:
     echo>: "logloss = ${td.last_results.logloss} (smaller is better)"

--- a/machine-learning/sfdc-predictive-analytics/queries/shuffle.sql
+++ b/machine-learning/sfdc-predictive-analytics/queries/shuffle.sql
@@ -4,7 +4,7 @@ SELECT
   T.job,
   -- stratified sampling
   count(1) over (partition by is_won) as per_label_count,
-  rank() over (partition by is_won order by rand(41)) as rank_in_label
+  rank() over (partition by is_won order by rand()) as rank_in_label
 FROM
   data C LEFT
 JOIN


### PR DESCRIPTION
The argument doesn't mean random seed. Presto cannot make random shuffling repeatable, as long as the data doesn't have reasonable UUID. We can alternatively use Hive to overcome the issue though.

Follow-up: #80 