### PR TITLE
remove "tab" as delimiter in README.md

### DIFF
--- a/td/sftp/README.md
+++ b/td/sftp/README.md
@@ -48,7 +48,7 @@ Available parameters for `result_settings` are here.
 - format: (string(csv|tsv), default csv)
 - compression: (string(None|gz|bzip2), default None)
 - header_line: (boolean(true|false), default true)
-- delimiter: (string(","|"\t"|"tab"), default ",")
+- delimiter: (string(","|"\t"), default ",")
 - quote_policy: (string(ALL|MINIMAL|NONE))
 - null_string: (string(""|"\N"|NULL|null), default "")
 - newline: (string(CRLF|CR|LF), default CRLF)


### PR DESCRIPTION
I remove "tab" as delimiter of result_settings in README.md.
Because this do not work correctly and we can use "\t" instead of "\tab".