### PR TITLE
Fix Python operator workflows for custom scripting private alpha

### DIFF
--- a/machine-learning/house_price/regression-py.dig
+++ b/machine-learning/house_price/regression-py.dig
@@ -28,7 +28,7 @@ _export:
     py>: tasks.FeatureSelector.run
     docker:
       # Note: This image is temporary. It might change in the near future.
-      image: 'chezou/td-ml-base:latest'
+      image: 'digdag/digdag-python:3.6.8-stretch'
     _env:
       TD_API_KEY: ${secret:apikey}
       TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/house_price/tasks/__init__.py
+++ b/machine-learning/house_price/tasks/__init__.py
@@ -6,7 +6,7 @@ class FeatureSelector(object):
     def __init__(self):
         import sys
         sys.path.append('/home/td-user/.local/lib/python3.6/site-packages')
-        os.system('pip install --user pandas scikit-learn scipy td-client pandas-td')
+        os.system(f'{sys.executable} -m pip install --user pandas scikit-learn scipy td-client pandas-td')
 
         self.apikey = os.getenv("TD_API_KEY")
         self.endpoint = os.getenv("TD_API_SERVER")

--- a/machine-learning/house_price/tasks/__init__.py
+++ b/machine-learning/house_price/tasks/__init__.py
@@ -4,7 +4,9 @@ import textwrap
 
 class FeatureSelector(object):
     def __init__(self):
-        os.system('pip install pandas scikit-learn scipy td-client pandas-td')
+        import sys
+        sys.path.append('/home/td-user/.local/lib/python3.6/site-packages')
+        os.system('pip install --user pandas scikit-learn scipy td-client pandas-td')
 
         self.apikey = os.getenv("TD_API_KEY")
         self.endpoint = os.getenv("TD_API_SERVER")

--- a/machine-learning/sentiment-analysis/predict.py
+++ b/machine-learning/sentiment-analysis/predict.py
@@ -6,8 +6,8 @@ from common import get_export_dir
 
 
 def run():
-    os.system("pip install --user tdclient boto3")
-    os.system("pip install --user tensorflow")
+    os.system(f"{sys.executable} -m pip install --user tdclient boto3")
+    os.system(f"{sys.executable} -m pip install --user tensorflow")
 
     import boto3
     import tensorflow as tf

--- a/machine-learning/sentiment-analysis/predict.py
+++ b/machine-learning/sentiment-analysis/predict.py
@@ -6,7 +6,8 @@ from common import get_export_dir
 
 
 def run():
-    #os.system("pip install pandas-td boto3")
+    os.system("pip install --user tdclient boto3")
+    os.system("pip install --user tensorflow")
 
     import boto3
     import tensorflow as tf

--- a/machine-learning/sentiment-analysis/sentiment-analysis.dig
+++ b/machine-learning/sentiment-analysis/sentiment-analysis.dig
@@ -23,7 +23,7 @@ _export:
   py>: sentiment.run
   docker:
     # Note: This image is temporary. It might change in the near future.
-    image: 'chezou/td-ml-base:latest'
+    image: 'digdag/digdag-python:3.6.8-stretch'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/sentiment-analysis/sentiment.py
+++ b/machine-learning/sentiment-analysis/sentiment.py
@@ -10,7 +10,10 @@ def run():
     # Original code is published at official document of TensorFlow under Apache License Version 2.0
     # https://www.tensorflow.org/hub/tutorials/text_classification_with_tf_hub
 
-    #os.system("pip install pandas-td tensorflow_hub boto3")
+    import sys
+    sys.path.append('/home/td-user/.local/lib/python3.6/site-packages')
+    os.system(f"{sys.executable} -m pip install --user pandas-td boto3")
+    os.system(f"{sys.executable} -m pip install --user tensorflow==1.11.0 tensorflow_hub==0.1.1 ")
 
     import boto3
     import tensorflow as tf

--- a/machine-learning/time_series/README.md
+++ b/machine-learning/time_series/README.md
@@ -1,9 +1,10 @@
 # Time series analysis with Prophet
 
 ***This is an experimental workflow. It doesn't work on production environment yet***
+***This example doesn't work for private alpha.***
 
 This example introduces time series for sales data prediction using [Facebook Prophet](https://facebook.github.io/prophet).
-Details are described in [the official document](https://facebook.github.io/prophet/docs/non-daily_data.html#monthly-data). 
+Details are described in [the official document](https://facebook.github.io/prophet/docs/non-daily_data.html#monthly-data).
 
 This workflow will:
 

--- a/machine-learning/time_series/predict.py
+++ b/machine-learning/time_series/predict.py
@@ -5,10 +5,9 @@ import io
 
 class TimeSeriesPredictor(object):
     def __init__(self):
-        import sys
         sys.path.append('/home/td-user/.local/lib/python3.6/site-packages')
-        os.system('pip install --user pandas matplotlib pandas-td boto3 pystan')
-        os.system('pip install --user fbprophet')
+        os.system(f'{sys.executable} -m pip install --user pandas matplotlib pandas-td boto3 pystan')
+        os.system(f'{sys.executable} -m pip install --user fbprophet')
 
         self.apikey = os.getenv("TD_API_KEY")
         self.endpoint = os.getenv("TD_API_SERVER")

--- a/machine-learning/time_series/predict.py
+++ b/machine-learning/time_series/predict.py
@@ -1,15 +1,15 @@
-import boto3
 import os
+import sys
 import io
 # Need to plot graph for Prophet
-import matplotlib as mlp
-mlp.use('agg')
-from matplotlib import pyplot as plt
-import pandas_td as td
-from fbprophet import Prophet
 
 class TimeSeriesPredictor(object):
     def __init__(self):
+        import sys
+        sys.path.append('/home/td-user/.local/lib/python3.6/site-packages')
+        os.system('pip install --user pandas matplotlib pandas-td boto3 pystan')
+        os.system('pip install --user fbprophet')
+
         self.apikey = os.getenv("TD_API_KEY")
         self.endpoint = os.getenv("TD_API_SERVER")
         self.dbname = 'timeseries'
@@ -21,6 +21,13 @@ class TimeSeriesPredictor(object):
         self.period = int(_period)
 
     def run(self):
+        import boto3
+        import matplotlib as mlp
+        mlp.use('agg')
+        from matplotlib import pyplot as plt
+        import pandas_td as td
+        from fbprophet import Prophet
+
         con = td.connect(apikey=self.apikey, endpoint=self.endpoint)
 
         engine = td.create_engine(

--- a/machine-learning/time_series/predict_sales.dig
+++ b/machine-learning/time_series/predict_sales.dig
@@ -8,7 +8,7 @@ _export:
   py>: predict.TimeSeriesPredictor.run
   docker:
     # Note: This image is temporary. It might change in the near future.
-    image: 'chezou/td-ml-base:latest'
+    image: 'digdag/digdag-python:3.6.8-stretch'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}


### PR DESCRIPTION
Since Python Custom script private alpha has limitations; root-less user and limited allowed images, this PR fixes workflows working appropriately with the current private alpha environment.

- [x] House pricing example with scikit-learn
- [ ] <del>Time series example with Prophet</del> -> it fails to install fbprophet due to memory limitation 
- [x] Sentiment analysis with TensorFlow
