### PR TITLE
Add AWS-free examples for ML Python workflows

### DIFF
--- a/machine-learning/sentiment-analysis/README.md
+++ b/machine-learning/sentiment-analysis/README.md
@@ -6,6 +6,7 @@ This example introduces sentiment analysis for movie reviews using TensorFlow an
 Original example is written in [the official document](https://www.tensorflow.org/hub/tutorials/text_classification_with_tf_hub).
 
 This workflow will:
+
 1. Fetch review data from Treasure Data
 2. Build a model with TensorFlow
 3. Store the model on S3
@@ -14,6 +15,13 @@ This workflow will:
 Currently, prediction with fetching model from S3 is not evaluated yet.
 
 ## Workflow
+
+There are two workflows:
+
+1. which uploads a trained model to Amazon S3 and prediction results to TD
+2. which uploads prediction results to TD.
+
+### An example workflow with Amazon S3
 
 ```bash
 $ ./data.sh # prepare example data
@@ -31,3 +39,18 @@ $ td workflow start sentiment sentiment-analysis --session now
 ```
 
 * [sentiment-analysis.dig](sentiment-analysis.dig)
+
+### An example workflow without Amazon S3
+
+```bash
+$ ./data.sh # prepare example data
+$ td workflow push sentiment
+$ td workflow secrets \
+  --project sentiment \
+  --set apikey \
+  --set endpoint
+# Set secrets from STDIN like: apikey=1/xxxxx, endpoint=https://api.treasuredata.com
+$ td workflow start sentiment sentiment-analysis-simple --session now
+```
+
+* [sentiment-analysis-simple.dig](sentiment-analysis-simple.dig)

--- a/machine-learning/sentiment-analysis/sentiment-analysis-simple.dig
+++ b/machine-learning/sentiment-analysis/sentiment-analysis-simple.dig
@@ -1,0 +1,30 @@
+_export:
+  !include : config/params.yml
+  td:
+    database: ${dbname}
+    engine: hive
+
++prepare:
+  +shuffle:
+    _parallel: true
+
+    +train:
+      td>: queries/shuffle.sql
+      source: movie_review_train
+      create_table: movie_review_train_shuffled
+
+    +test:
+      td>: queries/shuffle.sql
+      source: movie_review_test
+      create_table: movie_review_test_shuffled
+
+# Train with pre-trained model on TensorFlow Hub and store prediction results to TD
++train:
+  py>: sentiment.run
+  with_aws: false
+  docker:
+    # Note: This image is temporary. It might change in the near future.
+    image: 'digdag/digdag-python:3.6.8-stretch'
+  _env:
+    TD_API_KEY: ${secret:apikey}
+    TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/time_series/README.md
+++ b/machine-learning/time_series/README.md
@@ -15,6 +15,13 @@ This workflow will:
 
 ## Workflow
 
+There are two workflow examples:
+
+1. which uploads prediction results to TD as well as uploads predicted graphs to Amazon S3 and sends a notification to Slack
+2. which uploads prediction results. This doesn't require S3 and Slack
+
+### An example working with Amazon S3 and Slack
+
 ```bash
 $ ./data.sh # prepare example data
 $ td workflow push prophet
@@ -31,3 +38,18 @@ $ td workflow start prophet predict_sales --session now
 ```
 
 * [predict_sales.dig](predict_sales.dig)
+
+### An example working without AWS
+
+```bash
+$ ./data.sh # prepare example data
+$ td workflow push prophet
+$ td workflow secrets \
+ --project prophet \
+  --set apikey \
+  --set endpoint \
+# Set secrets from STDIN like: apikey=1/xxxxx, endpoint=https://api.treasuredata.com
+$ td workflow start prophet predict_sales_simple --session now
+```
+
+* [predict_sales_simple.dig](predict_sales_simple.dig)

--- a/machine-learning/time_series/predict_sales_simple.dig
+++ b/machine-learning/time_series/predict_sales_simple.dig
@@ -1,0 +1,20 @@
+_export:
+  !include : config/params.yml
+  td:
+    database: ${dbname}
+    engine: presto
+
++predict:
+  py>: predict.TimeSeriesPredictor.run
+  with_aws: false
+  docker:
+    # Note: This image is temporary. It might change in the near future.
+    image: 'digdag/digdag-python:3.6.8-stretch'
+  _env:
+    TD_API_KEY: ${secret:apikey}
+    TD_API_SERVER: ${secret:endpoint}
+    source_table: ${source_table}
+    target_table: ${target_table}
+    start_date: ${start_date}
+    end_date: ${end_date}
+    period: 3652


### PR DESCRIPTION
This PR introduces simple ML examples working only with Treasure Data since some customer might not have an AWS account.

