### PR TITLE
Use digdag-python:3.7 image for custom script

### DIFF
--- a/machine-learning/house_price/regression-py.dig
+++ b/machine-learning/house_price/regression-py.dig
@@ -27,8 +27,7 @@ _export:
   +feature_selection:
     py>: tasks.FeatureSelector.run
     docker:
-      # Note: This image is temporary. It might change in the near future.
-      image: 'digdag/digdag-python:3.7.3-stretch'
+      image: 'digdag/digdag-python:3.7'
     _env:
       TD_API_KEY: ${secret:apikey}
       TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/house_price/tasks/__init__.py
+++ b/machine-learning/house_price/tasks/__init__.py
@@ -5,7 +5,7 @@ import textwrap
 class FeatureSelector(object):
     def __init__(self):
         import sys
-        os.system(f'{sys.executable} -m pip install --user pandas-td')
+        os.system(f'{sys.executable} -m pip install pandas-td')
 
         self.apikey = os.getenv("TD_API_KEY")
         self.endpoint = os.getenv("TD_API_SERVER")

--- a/machine-learning/sentiment-analysis/predict.py
+++ b/machine-learning/sentiment-analysis/predict.py
@@ -6,8 +6,7 @@ from common import get_export_dir
 
 
 def run():
-    os.system(f"{sys.executable} -m pip install --user boto3")
-    os.system(f"{sys.executable} -m pip install --user tensorflow")
+    os.system(f"{sys.executable} -m pip install tensorflow==1.13.1")
 
     import boto3
     import tensorflow as tf

--- a/machine-learning/sentiment-analysis/predict_chainer.py
+++ b/machine-learning/sentiment-analysis/predict_chainer.py
@@ -6,7 +6,7 @@ from logging import DEBUG, StreamHandler, getLogger
 
 import numpy
 
-os.system(f"{sys.executable} -m pip install --user -U chainer pytd td-pyspark")
+os.system(f"{sys.executable} -m pip install -U chainer")
 
 import chainer
 import pytd.pandas_td as td

--- a/machine-learning/sentiment-analysis/sentiment-analysis-chainer.dig
+++ b/machine-learning/sentiment-analysis/sentiment-analysis-chainer.dig
@@ -14,8 +14,7 @@ _export:
   input_table: "movie_review_test_shuffled"
   output_table: "test_predicted_polarities_chainer"
   docker:
-    # Note: This image is temporary. It might change in the near future.
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/sentiment-analysis/sentiment-analysis-simple.dig
+++ b/machine-learning/sentiment-analysis/sentiment-analysis-simple.dig
@@ -12,8 +12,7 @@ _export:
   py>: sentiment.run
   with_aws: false
   docker:
-    # Note: This image is temporary. It might change in the near future.
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/sentiment-analysis/sentiment-analysis.dig
+++ b/machine-learning/sentiment-analysis/sentiment-analysis.dig
@@ -11,8 +11,7 @@ _export:
 +train:
   py>: sentiment.run
   docker:
-    # Note: This image is temporary. It might change in the near future.
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}
@@ -23,8 +22,7 @@ _export:
 #+predict:
 #  py>: predict.run
 #  docker:
-#    # Note: This image is temporary. It might change in the near future.
-#    image: 'chezou/td-ml-base:latest'
+#    image: 'digdag/digdag-python:3.7'
 #  _env:
 #    TD_API_KEY: ${secret:apikey}
 #    TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/sentiment-analysis/sentiment.py
+++ b/machine-learning/sentiment-analysis/sentiment.py
@@ -28,8 +28,8 @@ def run(with_aws=True):
     # https://www.tensorflow.org/hub/tutorials/text_classification_with_tf_hub
 
     import sys
-    os.system(f"{sys.executable} -m pip install --user pandas-td boto3")
-    os.system(f"{sys.executable} -m pip install --user tensorflow==1.13.1 tensorflow_hub==0.1.1 ")
+    os.system(f"{sys.executable} -m pip install pandas-td")
+    os.system(f"{sys.executable} -m pip install tensorflow==1.13.1 tensorflow_hub==0.1.1")
 
     import tensorflow as tf
     import tensorflow_hub as hub

--- a/machine-learning/time_series/predict.py
+++ b/machine-learning/time_series/predict.py
@@ -5,8 +5,7 @@ import io
 
 class TimeSeriesPredictor(object):
     def __init__(self):
-        os.system(f'{sys.executable} -m pip install --user pandas-td pystan')
-        os.system(f'{sys.executable} -m pip install --user fbprophet')
+        os.system(f'{sys.executable} -m pip install pandas-td')
 
         self.apikey = os.getenv("TD_API_KEY")
         self.endpoint = os.getenv("TD_API_SERVER")
@@ -19,7 +18,6 @@ class TimeSeriesPredictor(object):
         self.period = int(_period)
 
     def _upload_graph(self, model, forecast):
-        os.system(f'{sys.executable} -m pip install --user matplotlib boto3')
         import boto3
         import matplotlib as mlp
         mlp.use('agg')

--- a/machine-learning/time_series/predict_sales.dig
+++ b/machine-learning/time_series/predict_sales.dig
@@ -7,8 +7,7 @@ _export:
 +predict:
   py>: predict.TimeSeriesPredictor.run
   docker:
-    # Note: This image is temporary. It might change in the near future.
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}

--- a/machine-learning/time_series/predict_sales_simple.dig
+++ b/machine-learning/time_series/predict_sales_simple.dig
@@ -8,8 +8,7 @@ _export:
   py>: predict.TimeSeriesPredictor.run
   with_aws: false
   docker:
-    # Note: This image is temporary. It might change in the near future.
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}

--- a/python-scripting/get_row_count/get_row_count.dig
+++ b/python-scripting/get_row_count/get_row_count.dig
@@ -5,7 +5,7 @@ schedule:
 
 +step1:
   docker:
-    image: "digdag/digdag-python:3.7.3-stretch"
+    image: "digdag/digdag-python:3.7"
   py>: get_row_count.get_row_count
   dest_db: td_stats
   dest_table: row_count

--- a/python-scripting/kintone_sample/main.dig
+++ b/python-scripting/kintone_sample/main.dig
@@ -1,10 +1,10 @@
 timezone: Asia/Tokyo
 _export:
- docker:
-  image: "digdag/digdag-python:3.7.3-stretch"
- !include : 'config/kintone.yml'
- org: hogehoge
- 
+  docker:
+    image: "digdag/digdag-python:3.7"
+  !include : 'config/kintone.yml'
+  org: hogehoge
+
 +get:
   call>: get_records.dig
 

--- a/python-scripting/kintone_sample/python_args.py
+++ b/python-scripting/kintone_sample/python_args.py
@@ -2,8 +2,6 @@ import sys
 import os
 import os.path
 
-os.system(f"{sys.executable} -m pip install --user requests")
- 
 import pytd.pandas_td as td
 import requests
 import json

--- a/python-scripting/pandas-df/pandas-df.dig
+++ b/python-scripting/pandas-df/pandas-df.dig
@@ -3,7 +3,7 @@
     database_name: sample_datasets
     table_name: nasdaq
     docker:
-        image: "digdag/digdag-python:3.7.3-stretch"
+        image: "digdag/digdag-python:3.7"
     _env:
         TD_API_KEY: ${secret:apikey}
         TD_API_SERVER: ${secret:endpoint}
@@ -13,7 +13,7 @@
     database_name: pandas_test
     table_name: my_df
     docker:
-        image: "digdag/digdag-python:3.7.3-stretch"
+        image: "digdag/digdag-python:3.7"
     _env:
         TD_API_KEY: ${secret:apikey}
         TD_API_SERVER: ${secret:endpoint}

--- a/python-scripting/pandas-df/py_scripts/examples.py
+++ b/python-scripting/pandas-df/py_scripts/examples.py
@@ -1,7 +1,7 @@
 # Because we do not allow custom image currently, this is how you can add 3rd party
 # libraries instead
 import sys, os
-os.system(f"{sys.executable} -m pip install --user pandas-td")
+os.system(f"{sys.executable} -m pip install pandas-td")
 
 import pandas_td as td
 import tdclient

--- a/python-scripting/query-monitoring/query-monitoring.dig
+++ b/python-scripting/query-monitoring/query-monitoring.dig
@@ -3,7 +3,7 @@ schedule:
 
 +query-monitoring:
     docker:
-        image: "digdag/digdag-python:3.7.3-stretch"
+        image: "digdag/digdag-python:3.7"
     py>: query-monitoring.monitoring
     _env:
         td_apikey: ${secret:td.apikey}

--- a/python-scripting/rss_import/rss_import.dig
+++ b/python-scripting/rss_import/rss_import.dig
@@ -5,7 +5,7 @@ schedule:
 
 +step1:
   docker:
-    image: "digdag/digdag-python:3.7.3-stretch"
+    image: "digdag/digdag-python:3.7"
   py>: tasks.rss_import
   dest_db: rss_db
   dest_table: rss_tbl

--- a/python-scripting/rss_import/tasks.py
+++ b/python-scripting/rss_import/tasks.py
@@ -6,7 +6,7 @@ import os
 import os.path
 import time
 
-os.system(f"{sys.executable} -m pip install --user feedparser")
+os.system(f"{sys.executable} -m pip install feedparser")
 
 import pytd
 import pandas as pd

--- a/python-scripting/simple/simple.dig
+++ b/python-scripting/simple/simple.dig
@@ -2,7 +2,7 @@
     py>: py_scripts.examples.print_arg
     msg: "Hello World"
     docker:
-        image: "digdag/digdag-python:3.7.3-stretch"
+        image: "digdag/digdag-python:3.7"
 
 +simple_with_env:
     py>: py_scripts.examples.print_env
@@ -11,9 +11,9 @@
         # One can use secrets as well.
         # See https://support.treasuredata.com/hc/en-us/articles/360001266788-Workflows-Secrets-Management
     docker:
-        image: "digdag/digdag-python:3.7.3-stretch"
+        image: "digdag/digdag-python:3.7"
 
 +simple_with_import:
     py>: py_scripts.examples.import_another_file
     docker:
-        image: "digdag/digdag-python:3.7.3-stretch"
+        image: "digdag/digdag-python:3.7"

--- a/python-scripting/td-spark/pyspark.dig
+++ b/python-scripting/td-spark/pyspark.dig
@@ -3,7 +3,7 @@
   database_name: td_spark_example
   table_name: www_access_processed
   docker:
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}
@@ -13,7 +13,7 @@
   database_name: td_spark_example
   table_name: www_access_processed
   docker:
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}
@@ -23,7 +23,7 @@
   database_name: td_spark_example
   table_name: pandas_table
   docker:
-    image: 'digdag/digdag-python:3.7.3-stretch'
+    image: 'digdag/digdag-python:3.7'
   _env:
     TD_API_KEY: ${secret:apikey}
     TD_API_SERVER: ${secret:endpoint}

--- a/python-scripting/twitter-archiver/twitter-archiver.dig
+++ b/python-scripting/twitter-archiver/twitter-archiver.dig
@@ -3,7 +3,7 @@ schedule:
 
 +query-monitoring:
     docker:
-        image: "digdag/digdag-python:3.7.3-stretch"
+        image: "digdag/digdag-python:3.7"
     py>: twitter-archiver.search_and_archive
     _env:
         td_apikey: ${secret:td.apikey}

--- a/python-scripting/twitter-archiver/twitter-archiver.py
+++ b/python-scripting/twitter-archiver/twitter-archiver.py
@@ -3,7 +3,7 @@ from datetime import datetime as dt
 from mapping import mapping as mp
 from time import sleep
 
-os.system(f"{sys.executable} -m pip install --user TwitterSearch")
+os.system(f"{sys.executable} -m pip install TwitterSearch")
 from TwitterSearch import *
 
 TD_API_KEY = os.environ.get('td_apikey')


### PR DESCRIPTION
Use the latest Docker image, i.e. digdag-python:3.7 for custom scripting. This image includes pytd, td-pyspark, requests, boto3 by default. Also, it doesn't need to use `--user` option for `pip install` so that I removed it.

JFYI @nakajimajunko @hjmsano @ryutaroy @kiyoto 