### PR TITLE
fix(cdp_monitoring): skip 422 errors per item instead of crashing

### DIFF
--- a/scenarios/monitoring/cdp_monitoring/scripts/ingest_activation.py
+++ b/scenarios/monitoring/cdp_monitoring/scripts/ingest_activation.py
@@ -18,7 +18,10 @@ def get_activations_per_audience(base_url, headers, id):
 def get_all_activations(base_url, headers, id_list):
     l = []
     for i in id_list:
-        l.extend(get_activations_per_audience(base_url=base_url, headers=headers, id=i))
+        try:
+            l.extend(get_activations_per_audience(base_url=base_url, headers=headers, id=i))
+        except requests.exceptions.HTTPError as e:
+            print(f'Skipping audience {i}: {e}')
     return l
 
 def insert_activations(import_unixtime, endpoint, apikey, dest_db, dest_table, activations):

--- a/scenarios/monitoring/cdp_monitoring/scripts/ingest_journey_activation.py
+++ b/scenarios/monitoring/cdp_monitoring/scripts/ingest_journey_activation.py
@@ -22,9 +22,12 @@ def get_journey_activation(base_url, headers, id):
 def get_all_journey_activation(base_url, headers, ids):
     l = []
     for i in ids:
-        d = get_journey_activation(base_url, headers, i)
-        if d != None:
-            l.extend(d)
+        try:
+            d = get_journey_activation(base_url, headers, i)
+            if d != None:
+                l.extend(d)
+        except requests.exceptions.HTTPError as e:
+            print(f'Skipping journey {i}: {e}')
     return l
 
 def run(session_unixtime, dest_db, dest_table, journey_ids, api_endpoint='api.treasuredata.com', cdp_api_endpoint='api-cdp.treasuredata.com'):

--- a/scenarios/monitoring/cdp_monitoring/scripts/ingest_journey_summary.py
+++ b/scenarios/monitoring/cdp_monitoring/scripts/ingest_journey_summary.py
@@ -24,9 +24,12 @@ def get_journey_summary(base_url, headers, id):
 def get_all_journey_summary(base_url, headers, ids):
     l = []
     for i in ids:
-        d = get_journey_summary(base_url, headers, i)
-        if d != None:
-            l.append(d)
+        try:
+            d = get_journey_summary(base_url, headers, i)
+            if d != None:
+                l.append(d)
+        except requests.exceptions.HTTPError as e:
+            print(f'Skipping journey {i}: {e}')
     return l
 
 def run(session_unixtime, dest_db, dest_table, journey_ids, api_endpoint='api.treasuredata.com', cdp_api_endpoint='api-cdp.treasuredata.com'):


### PR DESCRIPTION
## Summary

- Three cdp_monitoring ingest scripts (`ingest_activation.py`, `ingest_journey_summary.py`, `ingest_journey_activation.py`) crash entirely when any single item returns a 422 from the CDP API
- Wrapped the per-item API call in each loop with `try/except requests.exceptions.HTTPError` so bad items are logged and skipped while all other records continue to ingest

## Test plan

- [x] Verify that a 422 response on one audience/journey ID no longer aborts the full run
- [x] Confirm skipped IDs appear in the workflow task logs as `Skipping audience/journey <id>: ...`
- [x] Confirm all non-422 rows are still written to `activations`, `journey_summary`, and `journey_activation` tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)