### PR TITLE
fix(ingest_policy): skip 403/HTTP errors per policy instead of crashing

### DIFF
--- a/scenarios/monitoring/basic_monitoring/scripts/ingest_policy.py
+++ b/scenarios/monitoring/basic_monitoring/scripts/ingest_policy.py
@@ -19,8 +19,11 @@ def get_all_policy_with_permission(api_endpoint, headers, policyid_list):
         url = 'https://%s/v3/access_control/policies/%d/permissions' % (api_endpoint, i)
         print(url)
         res = requests.get(url=url, headers=headers)
-        if res.status_code != requests.codes.ok:
+        try:
             res.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print('Skipping policy %d permissions: %s' % (i, e))
+            continue
         permissions = res.json()
         if len(permissions) != 0:
             data = {'id':i , 'permissions': json.dumps(permissions)}
@@ -33,8 +36,11 @@ def get_all_policy_with_column_permission(api_endpoint, headers, policyid_list):
         url = 'https://%s/v3/access_control/policies/%d/column_permissions' % (api_endpoint, i)
         print(url)
         res = requests.get(url=url, headers=headers)
-        if res.status_code != requests.codes.ok:
+        try:
             res.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print('Skipping policy %d column_permissions: %s' % (i, e))
+            continue
         column_permissions = res.json()
         if len(column_permissions) != 0:
             data = {'id': i, 'column_permissions': json.dumps(column_permissions)}
@@ -47,8 +53,11 @@ def get_all_assign_users(api_endpoint, headers, policyid_list):
         url = 'https://%s/v3/access_control/policies/%s/users' % (api_endpoint, i)
         print(url)
         res = requests.get(url=url, headers=headers)
-        if res.status_code != requests.codes.ok:
+        try:
             res.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print('Skipping policy %s users: %s' % (i, e))
+            continue
         assign_users = res.json()
         if len(assign_users) != 0:
             data = {'id': i, 'assign_users': json.dumps(assign_users)}


### PR DESCRIPTION
## Summary

- `ingest_policy.py` called `res.raise_for_status()` unconditionally inside the per-policy loops, so a single 403 (or any HTTP error) on one policy endpoint aborted the entire run and left the workflow in `error` state
- Wrapped `raise_for_status()` in `try/except requests.exceptions.HTTPError` in all three affected functions: `get_all_policy_with_permission`, `get_all_policy_with_column_permission`, `get_all_assign_users`
- Inaccessible policies are now logged and skipped; all accessible policies continue to be ingested normally

## Test plan

- [x] Confirm the script completes successfully when at least one policy returns 403 — skipped policies appear in logs, accessible ones are ingested
- [x] Confirm normal (all-200) runs are unaffected
- [x] Verify `initial_ingest_policy` and `incremental_ingest_policy` tasks no longer error on accounts where the API key lacks access to some policy endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)